### PR TITLE
즐겨찾기 서비스 계층 속 단일 삭제 메서드 내부 로직 수정

### DIFF
--- a/src/main/java/com/example/talky/domain/favorites/service/FavoriteServiceImpl.java
+++ b/src/main/java/com/example/talky/domain/favorites/service/FavoriteServiceImpl.java
@@ -86,13 +86,9 @@ public class FavoriteServiceImpl implements FavoriteService {
     public void delete(Long normalId, DeleteFavoriteReq req) {
         String sentence = req.getSentence();
 
-        /**
-         * FIXME
-         * NullPointerException -> UserNotFoundException
-         */
         NormalUser user = (NormalUser) userRepository.findById(normalId)
                 .orElseThrow(NullPointerException::new);
-        Favorite favorite = favoriteRepository.findById(normalId)
+        Favorite favorite = favoriteRepository.findByNormalUserIdAndSentence(normalId, sentence)
                 .orElseThrow(FavoriteNorFoundException::new);
 
         favoriteRepository.delete(favorite);


### PR DESCRIPTION
…ntence로 수정

# 🔹pr 템플릿

## 📝 작업 내용

<!-- 작업한 내용을 모두 작성해 주세요. -->

- 즐겨찾기 서비스 계층 내 단일 삭제 메서드에서 즐겨찾기를 조회하는 코드 findById -> findByNormalUserIdAndSentence로 수정

## #️⃣ 연관 이슈

<!-- 연관된 이슈를 태그해 주세요. -->
#이슈 번호
-closes #39 

## 👀 스크린샷

<!-- 결과 이미지를 첨부해 주세요. -->

<img width="501" height="551" alt="스크린샷 2025-09-09 오후 2 44 53" src="https://github.com/user-attachments/assets/3e86f95c-95ee-4ae3-ba0b-daa0a2118fcf" />

